### PR TITLE
switch to strncpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ to serve up.
 Building and Using
 ------------------
 
-Known to build on OS X and OpenBSD.
+Known to build on OS X, OpenBSD, ubuntu, and CentOS.
 
 Run the Makefile
 

--- a/src/lib/libServer.c
+++ b/src/lib/libServer.c
@@ -89,7 +89,7 @@ void web(int fd, int hit)
   }
 
   if( !strncmp(&buffer[0], "GET /\0",6) || !strncmp(&buffer[0], "get /\0",6) ) {
-    (void)strlcpy(buffer, "GET /index.html", sizeof(buffer));
+    (void)strncpy(buffer, "GET /index.html", sizeof(buffer));
   }
 
   buflen = strlen(buffer);

--- a/src/server.c
+++ b/src/server.c
@@ -34,22 +34,22 @@ int main(int argc, char **argv)
 
   // set default port and directory if nothing is passed in
   port = 8080;
-  strlcpy(char_port, "8080", sizeof(char_port));
-  strlcpy(char_dir, "html", sizeof(char_dir));
+  strncpy(char_port, "8080", sizeof(char_port));
+  strncpy(char_dir, "html", sizeof(char_dir));
 
   if (argc > 1) {
     for (int i = 1; i < argc; i++) {
       if ( strcmp(argv[i], "--port") == 0 || strcmp(argv[i], "-p") == 0) {
         i++;
         port = atoi(argv[i]);
-        strlcpy(char_port, argv[i], sizeof(char_port));
+        strncpy(char_port, argv[i], sizeof(char_port));
         if(port < 0 || port > 60000) {
           server_log(ERROR, "Invalid port number try [1,60000]", char_port, 0);
         }
       }
       if ( strcmp(argv[i], "--directory") == 0 || strcmp(argv[i], "-d") == 0) {
         i++;
-        strlcpy(char_dir, argv[i], sizeof(char_dir));
+        strncpy(char_dir, argv[i], sizeof(char_dir));
       }
       if ( strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
         help_msg(argv[0]);


### PR DESCRIPTION
this is to make it easier to compile on linux systems without the need for extra libraries.